### PR TITLE
Draft RFC-002 telemetry event catalog

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -3,4 +3,4 @@
 - 2025-09-20: Defer event schemas and SQL until Ingest MVP.
 - 2025-09-20: Ratified RFC-001 PRD covering problem statement, user targeting, scope, success metrics, and risks.
 - 2025-09-20: Selected MythClash and MythTag (Capivarious) as pilot titles for demo data and workflow validation.
-- 2025-09-20: Drafted RFC-002 telemetry event candidates for Ingest MVP (pending review).
+- 2025-09-21: Drafted RFC-002 telemetry event candidates for Ingest MVP (pending review).

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,3 +1,6 @@
 # Decision Log
 - 2025-09-20: Adopt JSON-only + error envelope format (final).
 - 2025-09-20: Defer event schemas and SQL until Ingest MVP.
+- 2025-09-20: Ratified RFC-001 PRD covering problem statement, user targeting, scope, success metrics, and risks.
+- 2025-09-20: Selected MythClash and MythTag (Capivarious) as pilot titles for demo data and workflow validation.
+- 2025-09-20: Drafted RFC-002 telemetry event candidates for Ingest MVP (pending review).

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -18,3 +18,5 @@ We will define the telemetry contract incrementally. For now, keep **principles*
 - (Performance/errors will be specified later)
 
 A formal spec (Zod/OpenAPI) will be generated during the **Ingest MVP** milestone.
+
+- Draft candidate events live in [RFC-002 — Telemetry Event Candidates](RFC/RFC-002.md) until schemas are finalized.

--- a/docs/RFC/RFC-002.md
+++ b/docs/RFC/RFC-002.md
@@ -1,0 +1,176 @@
+# RFC-002 — Telemetry Event Candidates
+
+**Status**: Draft for review  
+**Owners**: Product Manager, Tech Lead (PlayPulse)  
+**Reviewers**: Ingest Lead, Privacy/Security, Capivarious pilot devs
+
+## Context & Goals
+- Define the **initial telemetry surface** for the Ingest MVP without locking final schemas.  
+- Support pilot titles **MythClash** and **MythTag** with events that cover sessions, matches, and character engagement.  
+- Ensure every proposed field honors PlayPulse privacy guardrails and is feasible for the Godot SDK to emit.
+
+## Event Envelope (shared fields)
+All events include the following keys, emitted by the SDK and enforced at ingest:
+
+| Field | Type | Notes & Limits |
+| --- | --- | --- |
+| `event_id` | UUID v4 | SDK-generated per event. |
+| `event_name` | string (snake_case) | Max 48 chars. |
+| `schema_version` | string (`major.minor`) | Starts at `1.0`; additive changes bump minor, breaking changes bump major. |
+| `occurred_at` | ISO8601 string | Client timestamp in UTC. |
+| `session_id` | UUID v4 | Stable for duration of session; rotates on `session_start`. |
+| `player_id_hash` | hex string (64) | SHA-256 hash of salted player identifier stored locally; never raw IDs. |
+| `game_id` | enum (`mythclash`, `mythtag`) | Allows multi-title reporting. |
+| `game_version` | semver string | e.g., `0.6.2`. |
+| `build_id` | short string | ≤16 chars; maps to build pipeline artifact. |
+| `platform` | enum (`pc`, `mac`, `linux`) | Extendable later. |
+| `locale` | IETF BCP 47 string | Optional, max 8 chars (e.g., `en-US`). |
+| `consent_analytics` | boolean | Data from `false` is stored but excluded from analytics reads. |
+| `properties` | object | Event-specific payload capped at 1.5 KB uncompressed. |
+
+### Global limits
+- Event payload (envelope + properties) must remain **< 2 KB** to satisfy batching constraints.  
+- Arrays capped at **10 elements**; strings capped at **64 characters** unless otherwise noted.  
+- Numeric values are integers unless flagged as decimal; use base units (seconds, points) to avoid floats.
+
+## Candidate Event Catalog
+
+### `session_start`
+Purpose: record when a player launches or resumes the game.  
+Properties:
+- `launch_reason` (enum) — `fresh_launch`, `resume`, `hot_reload`.  
+- `connection_mode` (enum) — `online`, `offline`.  
+- `timezone_offset_min` (integer) — range -720 to 840; used only for retention bucketing.
+
+### `session_end`
+Purpose: capture how and when a player exits.  
+Properties:
+- `duration_s` (integer) — 0 to 86,400.  
+- `exit_reason` (enum) — `user_exit`, `disconnect`, `crash`, `idle_timeout`.  
+- `xp_earned` (integer) — 0 to 1,000, capping per session to prevent runaway values.
+
+### `match_start`
+Purpose: mark the beginning of a discrete match/battle instance.  
+Properties:
+- `match_id` (UUID v4) — generated client-side per match.  
+- `mode_id` (string) — ≤32 chars, e.g., `arena_ranked`.  
+- `map_id` (string) — ≤32 chars.  
+- `team_size` (integer) — 1 to 5.  
+- `party_size` (integer) — 1 to 4.  
+- `mmr_bucket` (enum) — `bronze`, `silver`, `gold`, `diamond` (extendable).
+
+### `match_end`
+Purpose: close out match analytics and tie back to outcomes.  
+Properties:
+- `match_id` (UUID v4) — must match `match_start`.  
+- `duration_s` (integer) — 0 to 7,200.  
+- `result` (enum) — `win`, `loss`, `draw`, `abandon`.  
+- `character_id` (string) — ≤32 chars.  
+- `score` (integer) — 0 to 100,000.  
+- `damage_dealt` (integer) — 0 to 500,000.
+
+### `character_selected`
+Purpose: understand roster balance and loadout preferences.  
+Properties:
+- `selection_context` (enum) — `match_lobby`, `armory`, `tutorial`.  
+- `character_id` (string) — ≤32 chars.  
+- `loadout_id` (string) — optional, ≤32 chars.  
+- `perk_ids` (array<string>) — max 5 entries, each ≤32 chars.  
+- `is_random` (boolean).
+
+### `tutorial_step_completed`
+Purpose: observe onboarding funnel completion for pilot games.  
+Properties:
+- `tutorial_id` (string) — ≤32 chars, e.g., `mythtag_intro`.  
+- `step_index` (integer) — 0 to 50.  
+- `step_key` (string) — ≤32 chars, stable identifier (e.g., `open_codex_menu`).  
+- `time_since_session_start_s` (integer) — 0 to 3,600.
+
+### Deferred / backlog events (not part of MVP)
+- `client_performance_sample` — awaiting perf instrumentation plan.  
+- `error_raised` — pending structured error taxonomy.  
+- `store_item_purchased` — outside current non-goals (monetization).
+
+## Custom Event Extensions (opt-in)
+- SDK supports additional events under the namespace `custom.<game_id>.<event_key>` once a schema is registered.  
+- Teams contribute a JSON schema (or Zod definition) for each custom event to `docs/events/custom/<game_id>/<event_key>.json`; CI validates schemas before deploy.  
+- Ingest only accepts custom events whose schema hash is published in configuration; others are sent to a quarantine table for manual review.  
+- Custom event payload rules: max 10 properties, primitive types only (string, integer, boolean, enum arrays), max payload size 1 KB.  
+- Per-title quota: 20 active custom event keys; overages require Product + Tech Lead approval.  
+- Dashboards treat custom events as exploratory data; they are excluded from default charts unless explicitly enabled.
+
+## Versioning & Evolution Policy
+- Initial release labeled **`schema_version` = `1.0`**.  
+- Additive fields to existing events → bump **minor** (1.x).  
+- New event types → reuse current major; document in RFC changelog.  
+- Removing/renaming fields or altering types → bump **major** and ship migration plan.  
+- SDK includes `schema_version` constant; Ingest rejects payloads with unsupported major versions and surfaces metrics per title.
+
+## Example Payloads
+```json
+{
+  "event_id": "7f4c9e4d-5f3c-4e51-9dc8-6e0a9f0c1234",
+  "event_name": "session_start",
+  "schema_version": "1.0",
+  "occurred_at": "2025-09-20T18:22:31Z",
+  "session_id": "bd1c2c1b-b9d3-4c0f-8b05-0cb089d3f3f9",
+  "player_id_hash": "c4a1f1d5a6294eab2ce8bba1f5b5fd27a9b6e0fead4b7d2a1a8cce71d2e9c2b1",
+  "game_id": "mythclash",
+  "game_version": "0.6.2",
+  "build_id": "mc-2025.09.18",
+  "platform": "pc",
+  "locale": "en-US",
+  "consent_analytics": true,
+  "properties": {
+    "launch_reason": "fresh_launch",
+    "connection_mode": "online",
+    "timezone_offset_min": -240
+  }
+}
+```
+
+```json
+{
+  "event_id": "1490f7d1-7772-4b51-a5f2-0e03ee9d83ce",
+  "event_name": "match_end",
+  "schema_version": "1.0",
+  "occurred_at": "2025-09-20T18:47:05Z",
+  "session_id": "ea0bc3d2-57f2-4da3-9881-431f2e2ad87f",
+  "player_id_hash": "5a0e37d47b83f85cf6335dcf28f17a99f61c85b9a3d2f26718a1f0fdc2cbd734",
+  "game_id": "mythtag",
+  "game_version": "0.3.0",
+  "build_id": "mt-2025.09.19",
+  "platform": "pc",
+  "locale": "pt-BR",
+  "consent_analytics": true,
+  "properties": {
+    "match_id": "2f9fe1c3-7d3a-4cb8-8bd8-1df54ad2a8a1",
+    "duration_s": 815,
+    "result": "win",
+    "character_id": "berserker",
+    "score": 3420,
+    "damage_dealt": 18750
+  }
+}
+```
+
+## Open Questions for Ingest MVP
+1. **Hashing strategy**: Do we salt `player_id_hash` per title or per device install to balance uniqueness vs. cross-title linkage?  
+2. **Offline buffering**: What is the maximum offline queue length/age before events are dropped to respect consent changes?  
+3. **Match identifiers**: Should the server override client-supplied `match_id` to avoid collisions in future multiplayer modes?  
+4. **Tutorial taxonomy**: Are `tutorial_step_completed` identifiers shared between MythClash and MythTag, or per-title?  
+5. **Schema enforcement**: Will Ingest mutate payload casing/order, or must SDK guarantee canonical ordering for HMAC signatures?  
+6. **Locale capture**: Should `locale` remain optional, or is it required to support localization analytics in the pilot?  
+7. **Custom event workflow**: Where will schema files live, who approves additions, and what telemetry surfaces should surface custom metrics by default?
+
+## Privacy Check
+- No raw identifiers, emails, IPs, chat logs, or free-text fields are collected.  
+- Hashing strategy ensures `player_id_hash` cannot be reversed without salt.  
+- Enums and bounded integers prevent leakage of sensitive strings.  
+- `timezone_offset_min` stored as integer; no actual timezone name.  
+- Consent flag retained to honor opt-out across aggregation layers.  
+- Custom event schemas are reviewable artifacts; ingest quarantine prevents unvetted payloads from entering analytics tables.
+
+## Next Steps
+- Review with Product, Tech Lead, and Privacy; update toys accordingly.  
+- Once approved, generate Zod schemas from this RFC and populate `EVENTS.md` with finalized definitions during Ingest MVP.


### PR DESCRIPTION
## What
- Capture RFC-002 with candidate telemetry events, envelope limits, and custom event policy

## Why
- Align on ingest MVP event surface while documenting gates for privacy-safe custom events

## How
- Add docs/RFC/RFC-002.md detailing shared fields, event payloads, versioning, and open questions
- Link EVENTS.md to the RFC while keeping the dictionary marked TBD
- Log the new RFC draft decision in DECISIONS.md

## Checks
- [ ] Tests added/updated
- [ ] Typecheck & lint pass
- [x] No secrets in code/logs
- [x] Docs updated (README/ARCHITECTURE/PLAYBOOK)
