### PR TITLE
Draft RFC-003 ingest security posture

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,3 +1,4 @@
 # Decision Log
 - 2025-09-20: Adopt JSON-only + error envelope format (final).
 - 2025-09-20: Defer event schemas and SQL until Ingest MVP.
+- 2025-09-20: Ratified RFC-003 ingest security posture (auth headers, replay window, rate limits, logging).

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -4,4 +4,4 @@
 - 2025-09-20: Ratified RFC-001 PRD covering problem statement, user targeting, scope, success metrics, and risks.
 - 2025-09-20: Selected MythClash and MythTag (Capivarious) as pilot titles for demo data and workflow validation.
 - 2025-09-21: Drafted RFC-002 telemetry event candidates for Ingest MVP (pending review).
-- 2025-09-20: Ratified RFC-003 ingest security posture (auth headers, replay window, rate limits, logging).
+- 2025-09-21: Ratified RFC-003 ingest security posture (auth headers, replay window, rate limits, logging).

--- a/docs/RFC/RFC-003.md
+++ b/docs/RFC/RFC-003.md
@@ -1,0 +1,81 @@
+# RFC-003 — Ingest Security Posture
+
+**Status**: Draft for review  
+**Owners**: Tech Lead, Security Lead  
+**Reviewers**: Backend Engineer, Privacy Officer, DevOps
+
+## Context & Goals
+- Lock the baseline security controls for the `POST /events` ingest endpoint before implementation begins.  
+- Align with existing privacy guardrails described in [PRIVACY.md](../PRIVACY.md) and threat mitigations in [SECURITY_THREAT_MODEL.md](../SECURITY_THREAT_MODEL.md).  
+- Provide concrete values (headers, limits, logging envelope) that the SDK, backend, and ops teams can build against.
+
+## Authentication & Header Contract
+Every request to `/events` MUST include:
+
+| Header | Example | Notes |
+| --- | --- | --- |
+| `X-Api-Key` | `pp_live_ca1c7...` | 32-byte hex string identifying the client/game build. |
+| `X-Signature` | `MEYCIQ...` | Base64-encoded HMAC-SHA256 signature (see formula). |
+| `X-Request-Timestamp` | `1726858805` | Unix epoch seconds when the payload was signed. |
+| `X-Nonce` | `f4c9f3e0-1e4d-4e4e-9c7b-6e8b5a23c4c1` | UUID v4 generated per request. |
+| `Content-Type` | `application/json` | Only JSON payloads are accepted. |
+
+### Signature Formula
+- Canonical payload string: `"{timestamp}\n{nonce}\n{raw_body}"` (newline-delimited).  
+- HMAC secret: 32-byte symmetric key provisioned alongside `X-Api-Key`.  
+- Algorithm: HMAC-SHA256; output base64-encoded.  
+- Verification rejects if body is re-encoded or if headers do not match the canonical string.  
+- SDK MUST sign the raw, uncompressed JSON bytes; server recreates the string exactly before verifying.
+
+## Replay Protection
+- Requests where `|now - X-Request-Timestamp| > 300` seconds (5 minutes) return `401` with error code `timestamp_out_of_window`.  
+- Server maintains an LRU cache for `(api_key, nonce)` pairs covering at least 5 minutes. Duplicates result in `409` with error code `replay_detected`.  
+- Cache eviction metrics surface via observability to detect suspicious volumes.  
+- Nonces stored as lowercase UUIDs to avoid normalization ambiguity.
+
+## CORS & Transport Policy
+- Default deny-all CORS.  
+- Allow-list origins: `https://dashboard.playpulse.dev`, `http://localhost:3000` (dev). Future origins added via configuration.  
+- Allowed methods: `POST`, `OPTIONS`.  
+- Allowed headers: `Content-Type`, `X-Api-Key`, `X-Signature`, `X-Request-Timestamp`, `X-Nonce`.  
+- Preflight cache max age: 600 seconds.  
+- HTTPS is required; HTTP requests are rejected before route handling.
+
+## Payload Limits & Rate Limiting
+- Maximum request size: **1 MB** (matches architectural docs) with early rejection at the load balancer.  
+- Per-IP rate limit: **120 requests/minute** with burst up to 240.  
+- Per-API-key limit: **600 requests/minute** with burst up to 1,200.  
+- Limits enforced before signature verification to reduce HMAC abuse.  
+- Throttled requests return `429` with `Retry-After` header (seconds until next allowed request).  
+- Rate limit counters reset every minute using sliding window algorithm.
+
+## Logging & Error Handling
+- Structured JSON logs capturing: `request_id`, hashed `api_key` (SHA-256), `remote_ip`, `user_agent`, request latency, response status, rate-limit decision, and signature result.  
+- **No request bodies or raw headers** logged, honoring [PRIVACY.md](../PRIVACY.md).  
+- Error responses follow the previously adopted envelope:
+
+```json
+{
+  "error": {
+    "code": "signature_invalid",
+    "message": "HMAC validation failed"
+  },
+  "request_id": "01J8YX3TKYAF9V0P7WBH54M2RB"
+}
+```
+
+- All error codes documented for SDK handling (`timestamp_out_of_window`, `replay_detected`, `rate_limited_ip`, `rate_limited_key`, `payload_too_large`, etc.).  
+- Log sampling applies only to successful requests; failures are always logged for audit.
+
+## Implementation Notes
+- SDKs must expose configuration for API key and signing secret, with rotation support.  
+- Backend secrets stored in vault; rotation playbook documented separately.  
+- Observability dashboards track rate-limit hits, signature failures, and replay rejections to align with the spoof/replay risks in [SECURITY_THREAT_MODEL.md](../SECURITY_THREAT_MODEL.md).
+
+## Open Questions
+1. Do we need regional key distribution (per deploy) to reduce blast radius if a key leaks?  
+2. Should we support batched event arrays with per-event signature, or rely solely on request-level signing?  
+3. What is the retention period for nonce caches and rate-limit counters in multi-instance deployments (shared Redis vs. in-memory)?
+
+## Decision
+Adopt the above ingest security posture for the Ingest MVP, with future iterations requiring an RFC update for any loosening of limits or alternative auth methods.


### PR DESCRIPTION
## What
- Document ingest API security posture in RFC-003

## Why
- Establish shared guardrails for authentication, replay protection, and logging before implementation

## How
- Add docs/RFC/RFC-003.md outlining header contract, signature formula, rate limits, CORS, and logging envelope
- Update docs/DECISIONS.md to log the adoption of RFC-003

## Checks
- [ ] Tests added/updated
- [ ] Typecheck & lint pass
- [x] No secrets in code/logs
- [x] Docs updated (README/ARCHITECTURE/PLAYBOOK)
