### PR TITLE
Add RFC-004 throughput assumptions and env defaults

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5,3 +5,4 @@
 - 2025-09-20: Selected MythClash and MythTag (Capivarious) as pilot titles for demo data and workflow validation.
 - 2025-09-21: Drafted RFC-002 telemetry event candidates for Ingest MVP (pending review).
 - 2025-09-21: Ratified RFC-003 ingest security posture (auth headers, replay window, rate limits, logging).
+- 2025-09-21: Ratified RFC-004 throughput assumptions, SLOs, and rate limit math for ingest MVP.

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -1,0 +1,21 @@
+# Environment Configuration (Placeholders)
+
+Set these variables in deployment environments to align with RFC-003 and RFC-004 targets. Values shown are defaults derived from current assumptions; adjust only with corresponding RFC updates.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `PLAYPULSE_INGEST_SLO_P95_MS` | `500` | Ingest p95 latency objective (ms). |
+| `PLAYPULSE_INGEST_SLO_P99_MS` | `900` | Ingest p99 latency objective (ms). |
+| `PLAYPULSE_ANALYTICS_SLO_P95_MS` | `300` | Analytics API p95 latency objective (ms). |
+| `PLAYPULSE_ANALYTICS_SLO_P99_MS` | `600` | Analytics API p99 latency objective (ms). |
+| `PLAYPULSE_INGEST_AVAILABILITY_TARGET` | `99.5` | Monthly availability target (%) for ingest. |
+| `PLAYPULSE_ANALYTICS_AVAILABILITY_TARGET` | `99.9` | Monthly availability target (%) for analytics read APIs. |
+| `PLAYPULSE_DATA_FRESHNESS_TARGET_MIN` | `15` | Maximum allowed data staleness (minutes). |
+| `PLAYPULSE_RATE_LIMIT_PER_KEY` | `600` | Sustained requests/minute per API key. |
+| `PLAYPULSE_RATE_LIMIT_PER_KEY_BURST` | `1200` | Burst requests/minute per API key. |
+| `PLAYPULSE_RATE_LIMIT_PER_IP` | `120` | Sustained requests/minute per IP. |
+| `PLAYPULSE_RATE_LIMIT_PER_IP_BURST` | `240` | Burst requests/minute per IP. |
+| `PLAYPULSE_REPLAY_WINDOW_SECONDS` | `300` | Replay protection window (seconds). |
+| `PLAYPULSE_STORAGE_RETENTION_DAYS` | `90` | Raw events retention horizon before archival. |
+
+> NOTE: update these values via infrastructure configuration; code should read from environment with documented defaults.

--- a/docs/RFC/RFC-004.md
+++ b/docs/RFC/RFC-004.md
@@ -1,0 +1,74 @@
+# RFC-004 — Throughput Assumptions & SLOs
+
+**Status**: Draft for review  
+**Owners**: Product Manager, Tech Lead  
+**Reviewers**: Backend Engineer, Analytics Lead, SRE/DevOps
+
+## Context & Goals
+- Establish explicit usage assumptions for MythClash and MythTag pilots.  
+- Size ingest/storage capacity and rate limits before implementation.  
+- Define service-level objectives (SLOs) and error budget policy for ingest and analytics APIs.
+
+## Usage Assumptions
+| Metric | Value | Notes |
+| --- | --- | --- |
+| Daily Active Users (DAU) | 5,000 | 3,000 MythClash + 2,000 MythTag. |
+| Sessions per DAU | 1.8 | Accounts for repeat logins during testing and dailies. |
+| Events per session | 45 | Includes core SDK events and limited custom usage. |
+| Average event payload | 0.9 KB | Envelope + bounded properties. |
+| Peak concurrency | 10 % of DAU (≈500 players) | Typical indie launch ratio. |
+| Peak event frequency | 0.25 events/sec/player | Match-phase cadence; SDK batches events. |
+
+### Derived Throughput
+- **Daily events**: 5,000 × 1.8 × 45 = **405,000 events/day**.  
+- **Average ingest rate**: 405,000 ÷ 86,400 ≈ **4.7 events/sec** (pre-batching).  
+- **Peak ingest rate**: 500 players × 0.25 = **125 events/sec** → with batches of 10 events per request ≈ **12.5 requests/sec**.  
+- **Storage growth**: 405,000 × 0.9 KB = **364,500 KB/day ≈ 356 MB/day** (binary). Over 30 days ≈ **10.7 GB/month**.  
+- **90-day retention**: ≈ **32 GB** raw before compression/rollups.
+
+## Service-Level Objectives
+### Ingest API (`POST /events`)
+- Availability: **99.5 %** monthly (error budget 0.5 % ≈ 3.6 hours/month).  
+- Latency: **p95 < 500 ms**, **p99 < 900 ms**.  
+- Data freshness: materialized views refresh within **15 minutes**, else counts against ingest error budget.  
+- Error budget policy: if ≥25 % of monthly budget burns in any 7-day window, freeze production feature deploys until remediation plan is executed.
+
+### Analytics API (read endpoints)
+- Availability: **99.9 %** monthly (error budget 0.1 % ≈ 43 minutes/month).  
+- Latency: **p95 < 300 ms**, **p99 < 600 ms** for cached dashboards.  
+- Freshness: mirrors ingest guarantee (≤15 minutes); violations log incidents for SRE review.
+
+### Error Budget Handling
+- Budgets reset on the first calendar day monthly.  
+- Production incidents consume budget; staging/previews tracked but do not impact budgets.  
+- Burn alerts at 25 %, 50 %, 75 % thresholds with agreed playbook (rollback, feature freeze, RCA).
+
+## Rate Limit Mathematics
+- **Per API key**: 600 requests/minute sustained, burst 1,200. With 10 events/request → 6,000 events/min sustained (100 events/sec) and 12,000 events/min burst. Legit peak load (≈12.5 req/sec) stays well under limits.  
+- **Per IP**: 120 requests/minute sustained, burst 240. Supports dozens of clients behind shared NAT while constraining abuse.  
+- **Replay window**: 300 seconds. Nonce cache sized for 1,200 req/min per key ≈ 6,000 active nonces.  
+- **Storage planning**: provision ≥50 GB raw for pilot phase (90-day retention + headroom).
+
+## ENV Configuration Mapping
+The following environment variables should surface these values for operational tuning (see [ENV.md](../ENV.md)):
+- `PLAYPULSE_INGEST_SLO_P95_MS=500`
+- `PLAYPULSE_ANALYTICS_SLO_P95_MS=300`
+- `PLAYPULSE_INGEST_SLO_P99_MS=900`
+- `PLAYPULSE_ANALYTICS_SLO_P99_MS=600`
+- `PLAYPULSE_INGEST_AVAILABILITY_TARGET=99.5`
+- `PLAYPULSE_ANALYTICS_AVAILABILITY_TARGET=99.9`
+- `PLAYPULSE_DATA_FRESHNESS_TARGET_MIN=15`
+- `PLAYPULSE_RATE_LIMIT_PER_KEY=600`
+- `PLAYPULSE_RATE_LIMIT_PER_KEY_BURST=1200`
+- `PLAYPULSE_RATE_LIMIT_PER_IP=120`
+- `PLAYPULSE_RATE_LIMIT_PER_IP_BURST=240`
+- `PLAYPULSE_REPLAY_WINDOW_SECONDS=300`
+- `PLAYPULSE_STORAGE_RETENTION_DAYS=90`
+
+## Open Questions
+1. Should we model weekend vs weekday load differently for ops paging windows?  
+2. Do we need per-region SLOs if we deploy ingest in multiple regions?  
+3. How will we forecast storage once CSV exports or additional events ship?
+
+## Decision
+Adopt the above assumptions, throughput targets, and SLO/error budget policy for the Ingest MVP. Adjustments require RFC amendments once pilot telemetry data is available.


### PR DESCRIPTION
## What
- Document throughput assumptions and service objectives in RFC-004

## Why
- Align engineering, analytics, and ops on expected ingest load and SLO/error budgets for the pilot

## How
- Add docs/RFC/RFC-004.md outlining DAU assumptions, throughput math, SLOs, and rate limits
- Introduce docs/ENV.md to surface environment variable defaults tied to RFC-003/004
- Update docs/DECISIONS.md with the RFC-004 ratification entry

## Checks
- [ ] Tests added/updated
- [ ] Typecheck & lint pass
- [x] No secrets in code/logs
- [x] Docs updated (README/ARCHITECTURE/PLAYBOOK)
