### PR TITLE
Document RFC-005 observability baseline

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5,3 +5,5 @@
 - 2025-09-20: Selected MythClash and MythTag (Capivarious) as pilot titles for demo data and workflow validation.
 - 2025-09-21: Drafted RFC-002 telemetry event candidates for Ingest MVP (pending review).
 - 2025-09-21: Ratified RFC-003 ingest security posture (auth headers, replay window, rate limits, logging).
+- 2025-09-21: Ratified RFC-004 throughput assumptions, SLOs, and rate limit math for ingest MVP.
+- 2025-09-21: Ratified RFC-005 observability metrics, alerts, and logging schema for ingest MVP.

--- a/docs/RFC/RFC-005.md
+++ b/docs/RFC/RFC-005.md
@@ -1,0 +1,83 @@
+# RFC-005 — Day 1 Observability
+
+**Status**: Draft for review  
+**Owners**: Tech Lead, DevOps Lead  
+**Reviewers**: Backend Engineer, Analytics Lead, Privacy Officer
+
+## Context & Goals
+- Define the initial observability surface for the ingest and analytics stack.  
+- Ensure metrics, logs, and traces meet privacy rules while supporting the SLOs from [RFC-004](RFC-004.md).  
+- Provide actionable alert thresholds with clear ownership for the pilot phase.
+
+## Metrics to Collect (Prometheus)
+| Metric | Type | Labels | Purpose |
+| --- | --- | --- | --- |
+| `ingest_requests_total` | counter | `status_class`, `outcome` | Track request volume and 2xx/4xx/5xx split. |
+| `ingest_request_duration_seconds` | histogram | `route`, `status_class` | Latency against ingest SLO (p95 500 ms). |
+| `ingest_events_enqueued_total` / `ingest_events_written_total` | counter | `source` | Detect mismatch between enqueued vs stored events. |
+| `ingest_backlog_events` | gauge | `queue` | Current queue depth; back-pressure signal. |
+| `ingest_signature_failures_total` | counter | `reason` | Monitor auth issues (signature, timestamp, nonce). |
+| `ingest_rate_limit_hits_total` | counter | `limit_type` | Watch for throttling on keys vs IPs. |
+| `analytics_requests_total` | counter | `endpoint`, `status_class` | Volume/error rate for read APIs. |
+| `analytics_request_duration_seconds` | histogram | `endpoint` | Latency vs analytics SLO (p95 300 ms). |
+| `mv_refresh_duration_seconds` | histogram | `mv_name` | Refresh times for materialized views. |
+| `mv_refresh_lag_seconds` | gauge | `mv_name` | Freshness gap; target ≤ 900 s. |
+| `db_connections_in_use` | gauge | `role` | Postgres pool saturation. |
+| `storage_raw_bytes` | gauge | `bucket` | Track raw event storage vs quota (daily scrape). |
+
+## Alert Policy & Ownership
+| Condition | Threshold | Duration | Owner | Action |
+| --- | --- | --- | --- | --- |
+| Ingest 5xx ratio | > 1 % of requests | 5 min | Backend on-call | Page; investigate recent deploys/logs. |
+| Ingest p95 latency | > 750 ms | 10 min | Backend on-call | Page; check DB, queue depth. |
+| Backlog depth | > 10,000 events OR growth >1,000/min | 5 min | DevOps on-call | Page; scale workers or investigate stuck queue. |
+| MV freshness | `mv_refresh_lag_seconds > 900` | 5 min | Analytics Lead | Page; trigger manual refresh, inspect job. |
+| Analytics 5xx ratio | > 0.5 % | 10 min | Backend on-call | Page; review recent changes, check downstream DB. |
+| Storage usage | > 80 % of provisioned | daily check | DevOps | Non-paging warning; plan capacity. |
+
+- Paging alerts send SMS/Slack to respective rotation; non-paging alerts post to ops Slack channel.  
+- On-call rotations documented in onboarding guide; default order: Tech Lead → Backend Eng for backend; DevOps lead → SRE backup for infra.  
+- Alert acknowledgments tracked in incident log; unresolved alerts escalate after 15 minutes.
+
+## Logging Schema (Structured JSON)
+- Applies to ingest service, analytics API, and refresh workers.  
+- Fields (privacy-safe by design):
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `ts` | string (ISO8601) | Timestamp of log event. |
+| `level` | string | `debug`/`info`/`warn`/`error`. |
+| `service` | string | `ingest`, `analytics`, `worker`. |
+| `request_id` | string | UUID assigned per request (propagated). |
+| `trace_id` | string | OpenTelemetry trace ID (when available). |
+| `route` | string | Route template (e.g., `/events`). |
+| `method` | string | HTTP method (`POST`, `GET`). |
+| `status_code` | integer | HTTP status for request logs. |
+| `latency_ms` | integer | Total processing time. |
+| `api_key_hash` | string | SHA-256 hash of API key; never raw key. |
+| `ip_prefix` | string | Truncated IP (`192.0.2.0/24`); IPv6 `/48`. |
+| `rate_limited` | boolean | `true` if request hit rate limiter. |
+| `error_code` | string/null | Application error code (e.g., `replay_detected`). |
+| `payload_bytes` | integer | Size of request body in bytes. |
+| `user_agent` | string | Sanitized user agent, truncated to 120 chars. |
+| `mv_name` | string | Name of materialized view (refresh logs only). |
+| `refresh_ms` | integer | Duration of MV refresh in ms (refresh logs). |
+| `rows_processed` | integer | Rows touched in MV refresh. |
+
+- No raw request bodies, player IDs, or PII stored.  
+- Logs ship to central store with 30-day retention, sampled at 20 % for `info` level, 100 % for `warn`/`error`.
+
+## Tracing Strategy
+- Enable OpenTelemetry tracing for ingest and analytics services.  
+- Sampling: 10 % of successful requests, 100 % of requests with `status_code >= 400`.  
+- Propagate `request_id` as `trace_id`; include span attributes: `route`, `status_code`, `api_key_hash`, `rate_limited`.  
+- Store spans in self-hosted Jaeger (or compatible backend) with 7-day retention.  
+- Workers emit spans for MV refresh jobs to correlate with freshness alerts.
+
+## Open Questions
+1. Do we need synthetic checks for analytics endpoints from multiple regions on day one?  
+2. Should we publish ingest metrics to a public status page during pilot?  
+3. What is the log retention requirement beyond 30 days for compliance?
+
+## Decision
+Adopt the above metrics, logging schema, and alert/trace configuration for the Ingest MVP observability baseline. Revisit once live telemetry validates assumptions.


### PR DESCRIPTION
## What
- Add RFC-005 covering day-1 observability metrics, alerts, logs, and tracing

## Why
- Ensure ingest and analytics services ship with measurable health targets and privacy-safe logging

## How
- Create docs/RFC/RFC-005.md detailing metrics, alert thresholds/owners, structured log schema, and trace sampling
- Update docs/DECISIONS.md to log the RFC-005 ratification

## Checks
- [ ] Tests added/updated
- [ ] Typecheck & lint pass
- [x] No secrets in code/logs
- [x] Docs updated (README/ARCHITECTURE/PLAYBOOK)
