### PR TITLE
Define RFC-007 Godot SDK surface

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,4 +8,4 @@
 - 2025-09-21: Ratified RFC-004 throughput assumptions, SLOs, and rate limit math for ingest MVP.
 - 2025-09-21: Ratified RFC-005 observability metrics, alerts, and logging schema for ingest MVP.
 - 2025-09-21: Ratified RFC-006 dashboard IA, initial charts, and k-anonymity UX for MVP.
-- 2025-09-21: Ratified RFC-007 Godot SDK surface, queue strategy, and reliability guarantees for MVP.
+- 2025-10-05: Ratified RFC-007 Godot SDK surface, queue strategy, and reliability guarantees for MVP.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,3 +8,4 @@
 - 2025-09-21: Ratified RFC-004 throughput assumptions, SLOs, and rate limit math for ingest MVP.
 - 2025-09-21: Ratified RFC-005 observability metrics, alerts, and logging schema for ingest MVP.
 - 2025-09-21: Ratified RFC-006 dashboard IA, initial charts, and k-anonymity UX for MVP.
+- 2025-09-21: Ratified RFC-007 Godot SDK surface, queue strategy, and reliability guarantees for MVP.

--- a/docs/RFC/RFC-007.md
+++ b/docs/RFC/RFC-007.md
@@ -1,0 +1,86 @@
+# RFC-007 — Godot SDK Surface & Reliability Guarantees
+
+**Status**: Draft for review  
+**Owners**: SDK Lead, Tech Lead  
+**Reviewers**: Backend Engineer, Privacy Officer, QA Lead
+
+## Context & Goals
+- Define the public API surface for the PlayPulse Godot 4 SDK.  
+- Establish queueing, batching, and backoff strategies aligned with ingest limits.  
+- Document performance budgets and failure behaviors so game teams know what to expect.
+
+## API Surface
+SDK is delivered as a Godot autoload (`PlayPulse`) initialized during game boot.
+
+| Method | Purpose | Notes |
+| --- | --- | --- |
+| `configure(config: Dictionary)` | Initialize SDK with credentials and runtime options. | Required keys: `api_key`, `signing_secret`, `game_id`, `game_version`, `build_id`. Optional: `player_seed`, `locale`, `initial_consent` (default `true`), `flush_interval_sec` (default 5). Generates/stores `device_id`, derives `player_id_hash`, opens persistence store, schedules flush timer. No events accepted before configure succeeds. |
+| `track(event_name: String, props: Dictionary = {})` | Enqueue event for delivery. | Auto-populates envelope (`event_id`, timestamps, session_id, schema_version, consent flag). Validates property sizes/types against RFC-002 caps. Returns `OK` or error code (`ERR_NOT_CONFIGURED`, `ERR_CONSENT_DISABLED`, `ERR_QUEUE_FULL`). |
+| `flush(force: bool = false)` | Trigger immediate send of queued events. | Sends batches up to 10 events. If `force`, bypasses interval guard. Returns `OK`/`ERR_NETWORK`, executes asynchronously but exposes awaitable signal for completion. |
+| `set_consent(enabled: bool)` | Toggle analytics consent. | Setting to `false` clears queue and persistence, future `track` no-ops until re-enabled. |
+| `set_player_identifier(seed: String)` | Re-derive `player_id_hash`. | Useful when a user logs into an account; pending queue flushed before swap. |
+| `shutdown()` | Flush outstanding events and close persistence. | Blocks up to 2 seconds on best-effort flush (used on quit). |
+
+Internal helpers (not part of public API) handle session lifecycle (`session_id` rotation), background worker, and diagnostics.
+
+## Queue & Transport Strategy
+- **In-memory queue cap**: 200 events. When length ≥ 10, enqueue task schedules immediate flush.  
+- **Flush interval**: default 5 s (configurable 2–30 s). Timer triggers flush even if queue < batch size to keep latency low.  
+- **Batch size**: up to 10 events per HTTP POST. Matches ingest expectations (`POST /events`).  
+- **Offline persistence**: append-only JSONL stored under `user://playpulse/events.log`. Capped at 2,000 events or 2 MB. Oldest entries dropped when limit exceeded (warning logged). On startup, persisted events replayed before new ones.  
+- **Backoff**: exponential with jitter per batch — 1 s, 5 s, 15 s, 60 s, 60 s (max). After five failed attempts, batch is persisted (if online fail) or dropped with error metric.  
+- **Compression**: gzip payload when batch body > 10 KB to reduce bandwidth.  
+- **Heartbeat**: if no successful flush in 120 s, emit warning log + telemetry metric for observability.  
+- **Session keep-alive**: `session_id` renewed after 30 minutes of inactivity or on explicit `session_start` event.
+
+## Performance Budget & Failure Behavior
+- **CPU**: `track` call does property validation + enqueue on main thread (<1 ms). JSON serialization + HMAC signing executed on background thread.  
+- **Memory**: queue + metadata < 512 KB; persistence file limited to 2 MB.  
+- **Network**: uses Godot `HTTPRequest` with async callback; main thread not blocked.  
+- **Consent disabled**: all `track` calls ignored (returns `ERR_CONSENT_DISABLED`). Queue cleared in-memory and on disk.  
+- **4xx responses** (auth, rate limit, schema): batch dropped, error logged, circuit opened for 60 s to avoid spam.  
+- **5xx/timeouts**: follow backoff strategy; persisted after retries exhausted.  
+- **Disk write failures**: fallback to memory-only mode; if queue overflows, newest events dropped with warning.  
+- **Shutdown**: `shutdown()` flushes synchronously (max 2 s). If still pending, events written to persistence so next launch retries.  
+- **Telemetry diagnostics**: SDK emits internal counters (optional log output) for queue length, flush success rate, consent state.
+
+## Example Usage (Godot 4 GDScript)
+```gdscript
+extends Node
+
+func _ready():
+    PlayPulse.configure({
+        "api_key": OS.get_environment("PLAYPULSE_API_KEY"),
+        "signing_secret": OS.get_environment("PLAYPULSE_SIGNING_SECRET"),
+        "game_id": "mythclash",
+        "game_version": "0.6.2",
+        "build_id": "mc-2025.09.18",
+        "player_seed": get_device_uuid(),
+        "locale": TranslationServer.get_locale(),
+        "initial_consent": true
+    })
+    PlayPulse.track("session_start", {
+        "launch_reason": "fresh_launch",
+        "connection_mode": "online"
+    })
+
+func start_match(match_id: String):
+    PlayPulse.track("match_start", {
+        "match_id": match_id,
+        "mode_id": "arena_ranked",
+        "team_size": 3
+    })
+
+func _notification(what):
+    if what == NOTIFICATION_WM_CLOSE_REQUEST:
+        PlayPulse.shutdown()
+        get_tree().quit()
+```
+
+## Open Questions
+1. Should we expose a `set_flush_interval` API for runtime tuning or rely solely on configure?  
+2. Do we need built-in sampling (e.g., drop % of events) for high-frequency combat logs?  
+3. Which consent-only events (e.g., `consent_updated`) must bypass the opt-out guard?
+
+## Decision
+Adopt the above SDK surface, queue strategy, and reliability guarantees for the Godot 4 MVP. Implementation details will follow in subsequent RFCs and tasks.


### PR DESCRIPTION
## What
- Document Godot SDK API surface, queue/persistence strategy, and reliability guarantees in RFC-007

## Why
- Align SDK implementation with ingest limits, consent requirements, and performance expectations for the MVP

## How
- Add docs/RFC/RFC-007.md describing configure/track/flush/consent APIs, queue/backoff settings, and failure behavior
- Update docs/DECISIONS.md to record the RFC-007 adoption

## Checks
- [ ] Tests added/updated
- [ ] Typecheck & lint pass
- [x] No secrets in code/logs
- [x] Docs updated (README/ARCHITECTURE/PLAYBOOK)
