### PR TITLE
Draft RFC-008 storage model plan

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,4 +8,5 @@
 - 2025-09-21: Ratified RFC-004 throughput assumptions, SLOs, and rate limit math for ingest MVP.
 - 2025-09-21: Ratified RFC-005 observability metrics, alerts, and logging schema for ingest MVP.
 - 2025-09-21: Ratified RFC-006 dashboard IA, initial charts, and k-anonymity UX for MVP.
-- 2025-10-05: Ratified RFC-007 Godot SDK surface, queue strategy, and reliability guarantees for MVP.
+- 2025-09-21: Ratified RFC-007 Godot SDK surface, queue strategy, and reliability guarantees for MVP.
+- 2025-09-21: Ratified RFC-008 storage model plan (events_raw partitions, derived views, refresh cadence).

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -1,10 +1,66 @@
-# ERD — TBD
+# ERD — Draft Plan
 
-The relational model (e.g., `events_raw` plus derived views) will be authored after the ingest contract is finalized.
+```mermaid
+erDiagram
+    events_raw ||--o{ mv_sessions_daily : feeds
+    events_raw ||--o{ mv_character_popularity : feeds
+    events_raw ||--o{ mv_retention_cohorts : feeds
+    dim_dates ||--o{ mv_sessions_daily : joins
+    dim_dates ||--o{ mv_character_popularity : joins
 
-**Principles:**
-- Append-only raw table for events.
-- Derived tables/materialized views for chart queries.
-- Indices added based on access patterns.
+    events_raw {
+        uuid event_id
+        timestamptz received_at
+        timestamptz occurred_at
+        text api_key_id
+        text game_id
+        uuid session_id
+        text player_id_hash
+        text event_name
+        text schema_version
+        jsonb props_jsonb
+        text ingest_source
+        timestamptz inserted_at
+    }
 
-*(A Mermaid ERD diagram will be added when fields are fixed.)*
+    mv_sessions_daily {
+        date metric_date
+        text game_id
+        text consent_bucket
+        integer session_count
+        integer active_players
+        interval avg_duration
+        boolean suppressed
+    }
+
+    mv_character_popularity {
+        date metric_date
+        text game_id
+        text character_id
+        integer pick_count
+        numeric pick_ratio
+        boolean suppressed
+    }
+
+    mv_retention_cohorts {
+        date cohort_date
+        text game_id
+        integer cohort_size
+        integer d1_retained
+        integer d7_retained
+        boolean d1_suppressed
+        boolean d7_suppressed
+    }
+
+    dim_dates {
+        date calendar_date
+    }
+```
+
+*Columns subject to change when schemas are finalized.*
+
+## Notes
+- `events_raw` remains append-only with 90-day retention.  
+- Materialized views refresh every 5 minutes (sessions/popularity) or nightly (retention).  
+- Zero-fill performed via `dim_dates` joins; suppressed buckets flagged in derived views.  
+- Additional dimensions (characters metadata, etc.) can be linked later.

--- a/docs/RFC/RFC-008.md
+++ b/docs/RFC/RFC-008.md
@@ -1,0 +1,66 @@
+# RFC-008 — Storage Model & Derived Views Plan
+
+**Status**: Draft for review  
+**Owners**: Data Engineer, Backend Lead  
+**Reviewers**: Analytics Lead, DevOps, Privacy Officer
+
+## Context & Goals
+- Sketch the relational layout for ingest MVP without locking final column names.  
+- Define derived views/tables that power analytics endpoints.  
+- Capture refresh cadence, zero-fill strategy, and primary access patterns.
+
+## Raw Event Storage (`events_raw`)
+- Append-only partitioned table (daily partitions on `received_at`).  
+- Columns (high level): `event_id`, `received_at`, `occurred_at`, `api_key_id`, `game_id`, `session_id`, `player_id_hash`, `event_name`, `schema_version`, `props_jsonb`, `ingest_source`, `inserted_at`.  
+- Primary key: `event_id` (UUID).  
+- Indexes:  
+  - BRIN on `received_at` for time-range scans.  
+  - B-tree on `(game_id, event_name, occurred_at)` for aggregations.  
+  - B-tree on `(player_id_hash, occurred_at)` for retention lookups.  
+  - Partial index on `event_name IN ('session_start','session_end')` to accelerate session derivations.  
+- Retention: keep partitions for 90 days (per RFC-004), prune older ones via cron.
+
+## Derived Views / Tables
+### `mv_sessions_daily`
+- Materialized view refreshed every 5 minutes (concurrently).  
+- Aggregates session events into daily counts, average duration, active players.  
+- Keys: `date`, `game_id`, `consent_bucket`.  
+- Includes `suppressed` flag when counts < 10.  
+- Zero-fill via join with `dim_dates` to ensure chart continuity.
+
+### `mv_character_popularity`
+- Materialized view refreshed every 5 minutes.  
+- Summarizes `character_selected` events by `game_id`, `date`, `character_id`.  
+- Stores `pick_count`, `pick_ratio`, `is_suppressed`.  
+- Index `(game_id, date DESC)` to support rolling 7-day queries.
+
+### `mv_retention_cohorts`
+- Derived table populated nightly (~02:00 UTC).  
+- Calculates cohorts from `session_start` events: `cohort_date`, `game_id`, `cohort_size`, `d1_retained`, `d7_retained`, `suppression_flags`.  
+- Index `(game_id, cohort_date)` for dashboard sort/filter.  
+- Allows manual refresh trigger (admin endpoint) when needed.
+
+### Supporting Structures
+- `dim_dates` table for zero-fill (stores calendar dates).  
+- Future dimension tables (e.g., `dim_characters`) can join for metadata but are out of MVP scope.
+
+## Refresh & Zero-Fill Strategy
+- `sessions` & `character` views refresh via cron every 5 minutes; optional on-demand endpoint for demos.  
+- `retention` table refresh nightly; manual rerun available.  
+- Refresh jobs log duration/row counts (feeds RFC-005 metrics).  
+- Zero-fill: generate date series per refresh window and LEFT JOIN to fill gaps with 0 counts; suppressed rows flagged so frontend merges/hides them.  
+- When more than 50% of points suppressed, the API signals empty state to dashboards.
+
+## Access Patterns
+- `/sessions/daily` API → `SELECT ... FROM mv_sessions_daily WHERE game_id = ? AND date BETWEEN ? AND ? ORDER BY date`.  
+- `/characters/popularity` → `SELECT ... FROM mv_character_popularity WHERE game_id = ? AND date BETWEEN CURRENT_DATE-7 AND CURRENT_DATE`.  
+- `/retention/cohorts` → `SELECT ... FROM mv_retention_cohorts WHERE game_id = ? ORDER BY cohort_date DESC`.  
+- Admin/debug queries may hit `events_raw` with filters on `(game_id, event_name, occurred_at)` thanks to indexes.
+
+## Open Questions
+1. Should we adopt TimescaleDB chunks instead of vanilla partitioning for automatic compression?  
+2. Do we need a `dim_players` table for long-term retention analysis beyond hashed IDs?  
+3. How will we snapshot data before pruning partitions (e.g., S3 archive)?
+
+## Decision
+Adopt the above storage layout, refresh cadence, and access patterns as the plan for ingest MVP. SQL specifics will be finalized once schemas are generated.


### PR DESCRIPTION
## What
- Add RFC-008 outlining the raw table partitions, derived views, refresh cadence, and zero-fill policy

## Why
- Align data, backend, and analytics on how ingest events flow into summaries before SQL is finalized

## How
- Create docs/RFC/RFC-008.md covering events_raw, materialized views, refresh schedules, and access patterns
- Update docs/ERD.md with a draft Mermaid diagram showing table relationships
- Log the decision in docs/DECISIONS.md

## Checks
- [ ] Tests added/updated
- [ ] Typecheck & lint pass
- [x] No secrets in code/logs
- [x] Docs updated (README/ARCHITECTURE/PLAYBOOK)
