### PR TITLE
Document RFC-009 ops runbooks

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -10,3 +10,4 @@
 - 2025-09-21: Ratified RFC-006 dashboard IA, initial charts, and k-anonymity UX for MVP.
 - 2025-09-21: Ratified RFC-007 Godot SDK surface, queue strategy, and reliability guarantees for MVP.
 - 2025-09-21: Ratified RFC-008 storage model plan (events_raw partitions, derived views, refresh cadence).
+- 2025-09-21: Ratified RFC-009 environment definitions, release process, and incident runbooks for MVP.

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -7,6 +7,45 @@
 ## PR checklist
 - Tests, typecheck, lint, docs, screenshots (if UI).
 
-## Local dev (coming next)
+## Local dev
 - `docker compose up -d` for Postgres
 - `pnpm dev` to start apps
+
+## Deployment Checklist
+- [ ] Merge PR with 2 approvals and green CI
+- [ ] Verify staging deploy (ingest health, dashboard login)
+- [ ] Tag release (`vYY.MM.DD`) and confirm prod deploy
+- [ ] Monitor alerts for 30 minutes post-release
+
+## Incident: Ingest Degradation
+- [ ] Acknowledge alert within 5 minutes
+- [ ] Check rate-limit hits, queue backlog, DB metrics
+- [ ] Scale ingest pods or throttle custom events if needed
+- [ ] Update #ops channel every 15 minutes
+- [ ] File RCA + follow-up tasks after resolution
+
+## Incident: Security Breach / Key Leak
+- [ ] Revoke impacted API keys immediately
+- [ ] Rotate signing/secret keys within 30 minutes
+- [ ] Notify stakeholders (internal + pilot studios)
+- [ ] Review access logs, preserve evidence
+- [ ] Complete RCA within 24 hours
+
+## Incident: Database Outage / Restore
+- [ ] Attempt failover to replica if available
+- [ ] Restore latest snapshot and apply WAL
+- [ ] Run smoke tests (ingest, analytics queries)
+- [ ] Re-enable ingest and monitor backlog
+- [ ] Document incident + remediation
+
+## Secrets Rotation Checklist
+- [ ] Schedule rotation window and notify team
+- [ ] Update secret in vault/manager
+- [ ] Redeploy services consuming secret
+- [ ] Verify health checks/logs
+- [ ] Record rotation in ops log
+
+## Backup Verification Checklist
+- [ ] Quarterly restore from snapshot to temp instance
+- [ ] Validate key queries on restored DB
+- [ ] Document results and adjust runbook if needed

--- a/docs/RFC/RFC-009.md
+++ b/docs/RFC/RFC-009.md
@@ -1,0 +1,88 @@
+# RFC-009 — Environments & Operational Runbooks
+
+**Status**: Draft for review  
+**Owners**: DevOps Lead, Tech Lead  
+**Reviewers**: Backend Engineer, Product Manager, Security Lead
+
+## Context & Goals
+- Define deployment environments (dev/stage/prod) and how secrets are managed.  
+- Align on release process (branch protection, CI gates).  
+- Capture initial incident playbooks and backup/restore expectations.
+
+## Environments
+### Development
+- Local dev with `.env.local` (mock keys) + shared cloud namespace (`dev`).  
+- Feature branches deploy to dev via preview builds (optional).  
+- Secrets stored in team vault (1Password/Doppler) with least privilege; local dev uses scoped API keys.  
+- Observability optional but recommended (logs/metrics accessible to engineers).
+
+### Staging
+- Mirrors production topology (ingest, Postgres, analytics API, dashboard).  
+- Runs sanitized demo data (no real player data).  
+- Deployments triggered by merge into `develop`.  
+- Secrets managed via cloud secret manager; rotation every 90 days.  
+- Access limited to engineering/product leads; all actions audited.
+
+### Production
+- Customer-facing environment with alerting + on-call coverage.  
+- Deployments only from tagged releases on `main`.  
+- Secrets restricted to on-call leads; rotation playbook executed immediately on leak.  
+- Full observability, audit logging, and WAF/CDN configuration.
+
+## Secrets Handling
+- No secrets committed to repo or stored in CI logs.  
+- Central secret store per environment (AWS Secrets Manager, Doppler, etc.).  
+- CI/CD pulls short-lived tokens to deploy; human access via SSO + MFA.  
+- Rotation cadence: 90 days for standard keys, 30 days for ingest signing keys; emergency rotation within 30 minutes of incident.  
+- Documented checklist for rotation (update secret → restart services → verify).
+
+## Release Process
+- Branching: `main` (prod), `develop` (stage), feature branches (`feat/<slug>`).  
+- PR requirements: 2 approvals, passing CI (lint, tests, typecheck, build).  
+- Merge to `develop` → deploy to staging automatically; run smoke tests (ingest ping, dashboard login, MV freshness).  
+- Release branch `release/YYYY-MM-DD` cut weekly (or as needed), tested on staging, then merged to `main` and tagged (`vYY.MM.DD`).  
+- Prod deploy: CI pipeline builds image, runs migrations (if any), deploys to prod, posts status updates.  
+- Rollback: keep previous successful tag; trigger `rollback` workflow or redeploy last tag via script; document time of rollback.
+
+## Incident Playbooks
+### Ingest Degradation (5xx/latency alerts)
+1. Acknowledge alert within 5 minutes (Backend on-call).  
+2. Check rate-limit metrics, queue backlog, DB health.  
+3. Mitigate: scale ingest pods, throttle custom events, clear stuck queue, escalate to DevOps if infra issue.  
+4. Communicate status in #ops channel every 15 minutes.  
+5. Post-incident: file RCA, update monitoring gaps.
+
+### Security Breach / Key Leak
+1. Trigger (suspicious auth, leaked key).  
+2. Within 30 minutes: revoke API keys, rotate signing secrets, tighten replay window.  
+3. Notify stakeholders (internal + pilot studio contacts) within 1 hour.  
+4. Review access logs, preserve evidence, open incident doc.  
+5. Complete full RCA in 24 hours with mitigation tasks.
+
+### Database Outage / Corruption
+1. Detect via DB alerts or dashboard data gaps.  
+2. Check read replica; failover if available.  
+3. Restore from latest snapshot (see backups), apply WAL to recovery point.  
+4. Verify `events_raw` integrity, re-run materialized view refresh.  
+5. Re-enable ingest, monitor backlog drain.
+
+## Backups & Restore
+- Postgres nightly snapshot + WAL archiving (7 daily, 4 weekly, 3 monthly).  
+- Snapshots stored encrypted in S3 with lifecycle policy.  
+- Quarterly restore test: spin up temp DB, restore snapshot, validate sample queries.  
+- Documented restore steps: select snapshot → provision restore → point services to new endpoint → run smoke tests.  
+- `events_raw` partitions pruned only after confirming snapshot success.
+
+## PLAYBOOK Checklist Additions
+- Deployment checklist: Pre-merge validation, staging verification, post-release monitoring.  
+- Incident checklists (ingest degraded, security breach, database outage) with triage/communication steps.  
+- Secrets rotation checklist (who, when, verification steps).  
+- Backup verification checklist (quarterly drill).
+
+## Open Questions
+1. Which CI tool (GitHub Actions vs. other) owns deployments/rollbacks?  
+2. Do we need separate on-call rotations for backend vs. infra at launch?  
+3. How will we notify pilot studios during incidents (email vs. status page)?
+
+## Decision
+Adopt the above environment definitions, release process, incident playbooks, and backup strategy for the ingest MVP operations.


### PR DESCRIPTION
## What
- Capture environment definitions, release process, and incident runbooks in RFC-009

## Why
- Align engineering and ops on how we deploy, secure, and respond to incidents for the MVP

## How
- Add docs/RFC/RFC-009.md detailing environments, secrets, release flow, incidents, and backups
- Expand docs/PLAYBOOK.md with deployment/incident/rotation checklists
- Update docs/DECISIONS.md to note RFC-009 adoption

## Checks
- [ ] Tests added/updated
- [ ] Typecheck & lint pass
- [x] No secrets in code/logs
- [x] Docs updated (README/ARCHITECTURE/PLAYBOOK)
